### PR TITLE
MOB-96 Support copying and pasting

### DIFF
--- a/app.js
+++ b/app.js
@@ -158,6 +158,18 @@ function createMainWindow() {
                 },
             ],
         },
+        {
+            label: "Edit",
+            submenu: [
+                { label: "Undo", accelerator: "CmdOrCtrl+Z", selector: "undo:" },
+                { label: "Redo", accelerator: "Shift+CmdOrCtrl+Z", selector: "redo:" },
+                { type: "separator" },
+                { label: "Cut", accelerator: "CmdOrCtrl+X", selector: "cut:" },
+                { label: "Copy", accelerator: "CmdOrCtrl+C", selector: "copy:" },
+                { label: "Paste", accelerator: "CmdOrCtrl+V", selector: "paste:" },
+                { label: "Select All", accelerator: "CmdOrCtrl+A", selector: "selectAll:" },
+            ],
+        },
     ];
 
     const menu = Menu.buildFromTemplate(template);


### PR DESCRIPTION
Supporting copying/pasting in Electron apps requires setting up menu items mapped to key-bindings.
In this PR, we're adding support for the following edit actions:
* Copy
* Paste
* Cut
* Select all
* Undo
* Redo